### PR TITLE
Fixed resourceName on EditButton

### DIFF
--- a/packages/core/src/components/buttons/edit/index.tsx
+++ b/packages/core/src/components/buttons/edit/index.tsx
@@ -72,7 +72,7 @@ export const EditButton: FC<EditButtonProps> = ({
     return (
         <Button
             onClick={(): void => {
-                edit(routeResourceName, id);
+                edit(resourceName, id);
             }}
             icon={<EditOutlined />}
             disabled={data?.can === false}


### PR DESCRIPTION
Fixed ignored property of resourceName on EditButton
closes #1400
